### PR TITLE
Updated  licenseNumber/licensePlate to registrationNumber in Vehicle

### DIFF
--- a/problems/parking-lot.md
+++ b/problems/parking-lot.md
@@ -31,11 +31,11 @@ Here's a simplified version of Java code:
 ### Vehicle Class
 ```java
 abstract class Vehicle {
-    private String licenseNumber;
+    private String registrationNumber;
     protected VehicleType type;
     
-    public Vehicle(String licensePlate, VehicleType type) {
-        this.licensePlate = licensePlate;
+    public Vehicle(String registrationNumber, VehicleType type) {
+        this.registrationNumber = registrationNumber;
         this.type = type;
     }
 


### PR DESCRIPTION
There was mismatch in the name, in declaration we used licenseNumber, but in the customer we used licensePlate. Instead we can better name it to registrationNumber(the number we see on the number plate is generally the registration number).