### PR TITLE
Update `DispenseState.java`

### DIFF
--- a/solutions/java/src/vendingmachine/DispenseState.java
+++ b/solutions/java/src/vendingmachine/DispenseState.java
@@ -24,8 +24,6 @@ public class DispenseState implements VendingMachineState {
 
     @Override
     public void dispenseProduct() {
-        vendingMachine.setState(vendingMachine.getReadyState());
-
         Product product = vendingMachine.getSelectedProduct();
         vendingMachine.inventory.updateQuantity(product, vendingMachine.inventory.getQuantity(product) - 1);
         System.out.println("Product dispensed: " + product.getName());


### PR DESCRIPTION
 It shouldn't need to set the status back to `ready` before dispensing product