### PR TITLE
Fix incorrect method definition in Car struct

### DIFF
--- a/oop/golang/classesandobjects/README.md
+++ b/oop/golang/classesandobjects/README.md
@@ -19,14 +19,14 @@ type Car struct {
     Make string
     Model string
     Year int
+}
 
-    // Method to display car details
-    func () DisplayInfo() {
-        fmt.Println("Car Make: " + Make)
-        fmt.Println("Car Model: " + Model)
-        fmt.Println("Car Year: " + Year)
-        fmt.Println("Car Color: " + Color)
-    }
+// Method defined with Car as the receiver
+func (c Car) DisplayInfo() {
+    fmt.Println("Car Make: " + c.Make)
+    fmt.Println("Car Model: " + c.Model)
+    fmt.Println("Car Year:", c.Year)
+    fmt.Println("Car Color: " + c.Color)
 }
 ```
 - **Attributes**: The struct `Car` has four attributes that describe its state: `Color`, `Make`, `Model`, and `Year`.


### PR DESCRIPTION
This pull request refactors the `DisplayInfo` method in the `Car` struct to use a receiver, improving clarity and adhering to Go's conventions for defining methods on structs.

Changes to method definition:

* The `DisplayInfo` method was moved from being defined inside the `Car` struct to being defined as a method with `Car` as the receiver. This change ensures the method operates on a specific instance of `Car` and accesses its fields using the receiver variable `c`.