### PR TITLE
Fix private field access error in Aggregation example by adding getter methodUpdated Java code in  aggregation README

### DIFF
--- a/oop/java/aggregation/README.md
+++ b/oop/java/aggregation/README.md
@@ -32,6 +32,10 @@ class Professor {
         this.subject = subject;
     }
     
+    public String getName(){
+        return name;
+    }
+    
     public void teach() {
         System.out.println(name + " is teaching " + subject);
     }
@@ -53,7 +57,7 @@ class University {
     public void showProfessors() {
         System.out.println("Professors at " + universityName + ":");
         for (Professor professor : professors) {
-            System.out.println(" - " + professor.name);
+            System.out.println(" - " + professor.getName());
         }
     }
 }


### PR DESCRIPTION
This pull request resolves a compilation error in the Java Aggregation example.

🔧 Changes Made:
Added a getName() method in the Professor class to properly access the private name field.

Replaced direct field access (professor.name) in the University class with a call to professor.getName().

🐞 Issue Fixed:
In the original code, the showProfessors() method attempted to access professor.name, which is declared private in the Professor class. This violates encapsulation and causes a compilation error.

✅ Outcome:
The updated code now compiles and runs correctly, maintaining object-oriented principles by using proper encapsulation.

Before Changes:
![image](https://github.com/user-attachments/assets/6f9892ee-b1a1-4854-910b-4355a7deeee2)

After Changes:
![image](https://github.com/user-attachments/assets/e1d9ad57-636f-470d-85f5-3446f4a2b4b5)
