### PR TITLE
Fix C++ visitor pattern accept implementations

### DIFF
--- a/design-patterns/cpp/visitor/circle.cpp
+++ b/design-patterns/cpp/visitor/circle.cpp
@@ -1,0 +1,13 @@
+#include "circle.h"
+
+#include "shape_visitor.h"
+
+Circle::Circle(double radius) : radius(radius) {}
+
+double Circle::getRadius() const {
+    return radius;
+}
+
+void Circle::accept(ShapeVisitor* visitor) {
+    visitor->visitCircle(this);
+}

--- a/design-patterns/cpp/visitor/circle.h
+++ b/design-patterns/cpp/visitor/circle.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "shape.h"
+
+class Circle : public Shape {
+public:
+    explicit Circle(double radius);
+
+    double getRadius() const;
+    void accept(ShapeVisitor* visitor) override;
+
+private:
+    double radius;
+};

--- a/design-patterns/cpp/visitor/main.cpp
+++ b/design-patterns/cpp/visitor/main.cpp
@@ -1,0 +1,26 @@
+#include "circle.h"
+#include "rectangle.h"
+#include "shape_visitor.h"
+
+#include <iostream>
+
+class ShapeDetailsVisitor : public ShapeVisitor {
+public:
+    void visitCircle(Circle* circle) override {
+        std::cout << "Circle radius: " << circle->getRadius() << '\n';
+    }
+
+    void visitRectangle(Rectangle* rectangle) override {
+        std::cout << "Rectangle width: " << rectangle->getWidth()
+                  << ", height: " << rectangle->getHeight() << '\n';
+    }
+};
+
+int main() {
+    Circle circle(5.0);
+    Rectangle rectangle(4.0, 6.0);
+    ShapeDetailsVisitor visitor;
+
+    circle.accept(&visitor);
+    rectangle.accept(&visitor);
+}

--- a/design-patterns/cpp/visitor/rectangle.cpp
+++ b/design-patterns/cpp/visitor/rectangle.cpp
@@ -1,0 +1,17 @@
+#include "rectangle.h"
+
+#include "shape_visitor.h"
+
+Rectangle::Rectangle(double width, double height) : width(width), height(height) {}
+
+double Rectangle::getWidth() const {
+    return width;
+}
+
+double Rectangle::getHeight() const {
+    return height;
+}
+
+void Rectangle::accept(ShapeVisitor* visitor) {
+    visitor->visitRectangle(this);
+}

--- a/design-patterns/cpp/visitor/rectangle.h
+++ b/design-patterns/cpp/visitor/rectangle.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shape.h"
+
+class Rectangle : public Shape {
+public:
+    Rectangle(double width, double height);
+
+    double getWidth() const;
+    double getHeight() const;
+    void accept(ShapeVisitor* visitor) override;
+
+private:
+    double width;
+    double height;
+};

--- a/design-patterns/cpp/visitor/shape.h
+++ b/design-patterns/cpp/visitor/shape.h
@@ -1,0 +1,9 @@
+#pragma once
+
+class ShapeVisitor;
+
+class Shape {
+public:
+    virtual ~Shape() = default;
+    virtual void accept(ShapeVisitor* visitor) = 0;
+};

--- a/design-patterns/cpp/visitor/shape_visitor.h
+++ b/design-patterns/cpp/visitor/shape_visitor.h
@@ -1,0 +1,11 @@
+#pragma once
+
+class Circle;
+class Rectangle;
+
+class ShapeVisitor {
+public:
+    virtual ~ShapeVisitor() = default;
+    virtual void visitCircle(Circle* circle) = 0;
+    virtual void visitRectangle(Rectangle* rectangle) = 0;
+};


### PR DESCRIPTION
## Fixes #220

This PR fixes the incomplete C++ Visitor Pattern example by implementing the missing `accept()` methods in the `Circle` and `Rectangle` classes.

### What changed

* Implemented `Circle::accept()` to delegate to `ShapeVisitor::visitCircle()`.
* Implemented `Rectangle::accept()` to delegate to `ShapeVisitor::visitRectangle()`.
* Kept the implementation consistent with the Visitor Pattern's double-dispatch mechanism.

### Why

The `accept()` methods were previously only declared but not defined, which resulted in linker errors when the example was compiled.

The implementations now correctly dispatch each concrete shape to the corresponding visitor method.

### Validation

* Compiled the C++ Visitor Pattern example successfully.
* Verified that the example runs without linker errors and that the appropriate visitor methods are invoked.
